### PR TITLE
fix audio_reader bug

### DIFF
--- a/samplernn/audio_reader.py
+++ b/samplernn/audio_reader.py
@@ -11,9 +11,11 @@ import numpy as np
 import tensorflow as tf
 
 def randomize_files(files):
-  for file in files:
-    file_index = random.randint(0, (len(files) - 1)) 
-    yield files[file_index]
+  files_idx= [i for i in xrange(len(files))]
+  random.shuffle(files_idx)
+
+  for idx in xrange(len(files)):
+    yield files[files_idx[idx]]
 
 def find_files(directory, pattern='*.wav'):
   '''Recursively finds all files matching the pattern.'''


### PR DESCRIPTION
 解决 pr #3 引入的 audio load 不全问题，线下测试如下：
```shell
files length: 14
./pinao-corpus/10.wav
./pinao-corpus/8.wav
./pinao-corpus/4.wav
./pinao-corpus/1.wav
./pinao-corpus/9.wav
./pinao-corpus/21.wav
./pinao-corpus/12.wav
./pinao-corpus/13.wav
./pinao-corpus/5.wav
./pinao-corpus/3.wav
./pinao-corpus/11.wav
./pinao-corpus/2.wav
./pinao-corpus/7.wav
./pinao-corpus/6.wav
```